### PR TITLE
Two small changes

### DIFF
--- a/pidtool.py
+++ b/pidtool.py
@@ -178,7 +178,7 @@ def resample_branch(options):
             deps = chunk[task["features"]]
             for pid in task["pids"]:
                 chunk[pid["name"]] = pid["resampler"].sample(deps.values.T)
-        chunk.to_root(options.output_file, mode="a")
+        chunk.to_root(options.output_file, options.tree.split("/")[-1], mode="a")
         logging.info('Processed {} entries'.format((i+1) * chunksize))
 
 


### PR DESCRIPTION
1. The tree in the output file has now the same name as the one in the input file. Before it was named "default" which can cause trouble when using root form commandline as default is a keyword in c++
2. The user can now pass a binning scheme to the create_resamplers method via
   --binningFile and --binningName options similar as in PIDCalibs MakePerfHistsRunRange.py
