### PR TITLE
Parallelisation and transformation

### DIFF
--- a/TrafoProbNN.py
+++ b/TrafoProbNN.py
@@ -1,0 +1,199 @@
+#!/usr/bin/python
+import ROOT
+import array
+import itertools
+import numpy as np
+import math
+from argparse import ArgumentParser
+from get_any_tree import get_any_tree
+# import progressbar
+import os.path
+
+
+def back_transform(var):
+    '''
+    Performs the back transformation of ProbNN variables, using numpy magic
+    for huge speedup when passing arrays to this function.
+    This function does not return anything, but changes the passed array in
+    place.
+    For the per-event back transformation when looping over a TTree use
+    UntrafoProbNN
+    '''
+    error_mask = var < -500
+
+    return (-2*error_mask.astype(int)
+            + (~error_mask).astype(int)*(np.exp(var) / (1 + np.exp(var))))
+
+
+def trafoProbNN(variable_name, event):
+    '''
+    Returns the transformed value of a variable
+
+    Keyword arguments:
+    variable_name -- name of the variable to transform
+    event -- a event in a ttree
+    '''
+    # calculate transformation of given variable
+    # given is a variable name and the event
+    variable = event.__getattr__(variable_name)
+
+    # C heck for problematic ProbNN values
+    if variable <= 0.0 or variable >= 1.0:
+        # -1000 or -2 is the default value when ProbNN could not be read when
+        # creating the tuples
+        if variable_name not in problem_branches:
+            problem_branches[variable_name] = 1
+        else:
+            problem_branches[variable_name] += 1
+        return -1000.    # also return -1000
+
+    return np.log(variable/(1-variable))
+
+
+def UntrafoProbNN(variable_name, event):
+    # given is a variable name and the event
+    variable = event.__getattr__(variable_name)
+
+    # Check for problematic transformed ProbNN values
+    if variable < -500:
+        return -2.
+    else:
+        return np.exp(variable) / (1 + np.exp(variable))
+
+
+if __name__ == '__main__':
+    # Read options
+    # Create optionparser
+    parser = ArgumentParser(
+        usage=("Tool to transform ProbNN-variables according to"
+               "log(X_ProbNNY/(1-X_ProbNNY))")
+    )
+
+    parser.add_argument("-i", "--input", dest="Input", action="store",
+                        required=True, help="Input ROOT-file")
+    parser.add_argument("-t", "--tree", dest="Tree", action="store",
+                        required=False,
+                        help=("Input TTree (optional if there is only one tree"
+                              " in the input-file)"))
+    parser.add_argument("-o", "--output", dest="Output", action="store",
+                        required=True, help="Output ROOT-file")
+    parser.add_argument("Variables", metavar='V', type=str, nargs='*',
+                        help=("Explicit variable name or variable names to be"
+                              " transformed"))
+    parser.add_argument("-m", "--match", dest="Patterns", action="append",
+                        required=False,
+                        help="Transform all variables matching this pattern")
+    parser.add_argument("-r", "--reverse", dest="Reverse", action="store_true",
+                        help=("Perform inverse transformation"
+                              " exp(X_ProbNNY)/(1+exp(X_ProbNNY))"))
+
+    options = parser.parse_args()
+
+    inputfile = ROOT.TFile(options.Input, "READ")
+    if not inputfile.IsOpen():
+        raise SystemExit("Could not open inputfile!")
+
+    if not options.Tree:
+        inputtreename = get_any_tree(options.Input)
+    else:
+        inputtreename = options.Tree
+
+    inputtree = inputfile.Get(inputtreename)
+
+    outputfile = options.Output
+
+    outputfile = ROOT.TFile(options.Output, "RECREATE")
+    outputtree = inputtree.CloneTree(0)
+
+    # Get explicit variable names
+    variable_names = options.Variables
+
+    # Create new branches for explicit variable names
+    variable_trafo_branches = []
+    for variable_name in variable_names:
+        variable_trafo_branches.append(array.array("d", [0.0]))
+        if options.Reverse:
+            # If var-name has "Trafo" in it, change it to "Untrafo",
+            # otherwise append Untrafo
+            if "Trafo" in variable_name:
+                outputbranchname = variable_name.replace("Trafo", "Untrafo")
+            else:
+                outputbranchname = variable_name + "_Untrafo"
+            outputtree.Branch(outputbranchname, variable_trafo_branches[-1],
+                              outputbranchname+"/D")
+        else:
+            outputtree.Branch(variable_name+"_Trafo",
+                              variable_trafo_branches[-1],
+                              variable_name+"_Trafo/D")
+
+    # Get variable names matching the patterns (if applicable)
+    if options.Patterns:
+        for pattern in options.Patterns:
+            for branch in inputtree.GetListOfBranches():
+                if pattern in branch.GetName():
+                    variable_name = branch.GetName()
+                    variable_names.append(variable_name)
+                    variable_trafo_branches.append(array.array("d", [0.0]))
+                    if options.Reverse:
+                        # If var-name has "Trafo" in it, change it to
+                        # "Untrafo", otherwise append Untrafo
+                        if "Trafo" in variable_name:
+                            outputbranchname = variable_name.replace("Trafo",
+                                                                     "Untrafo")
+                        else:
+                            outputbranchname = variable_name + "_Untrafo"
+                        outputtree.Branch(outputbranchname,
+                                          variable_trafo_branches[-1],
+                                          outputbranchname+"/D")
+                    else:
+                        outputtree.Branch(variable_name+"_Trafo",
+                                          variable_trafo_branches[-1],
+                                          variable_name+"_Trafo/D")
+
+    if len(variable_names) is 0:
+        raise SystemExit(
+            ("No variables for transformation given/found "
+             "for {}").format(options.Input))
+
+    # Create dictionary that will contain the branch names, where invalid
+    # ProbNN values were encountered (i.e. outside of 0 to 1)
+    # and attached to the branch names the number of events there an error
+    # occured
+    problem_branches = {}
+
+    entries = inputtree.GetEntries()
+    print("Processing {0} entries in {2} /{1}".format(entries, inputtreename,
+                                                      options.Input))
+    print("\nThe following variables will be transformed:")
+    print(", ".join(variable_names))
+    print("\n")
+
+    for (i, event) in itertools.izip(xrange(entries), inputtree):
+        inputtree.GetEntry(i)
+
+        # iterate through variables
+        for (variable_name, variable_trafo_branch)\
+                in itertools.izip(variable_names, variable_trafo_branches):
+            if options.Reverse:
+                variable_trafo_branch[0] = UntrafoProbNN(variable_name, event)
+            else:
+                variable_trafo_branch[0] = trafoProbNN(variable_name, event)
+
+        outputtree.Fill()
+
+    if problem_branches:
+        print(("\n\nWARNING: There were events with ProbNN-values outside the"
+               " allowed region of [0,1] for {}:").format(options.Input))
+        print("{:<20} {:>15} {:>10}".format(
+            'Branch', 'Probl. Events', 'Percent'))
+        for branch, events in problem_branches.iteritems():
+                print("{:<20} {:>15} {:>10}%".format(
+                    branch, events, float(events)/entries*100.))
+        print(("\t=> Setting these to -1000 (Default value for"
+               "ProbNN-variables if none was found when creating the ntuple)"))
+
+    print(("\nFinished processing {0} entries in {2} /{1}\n\t=> Writing to"
+           " {3}").format(entries, inputtreename,
+                          options.Input, options.Output))
+    outputtree.Write()
+    outputfile.Close()

--- a/TrafoProbNN.py
+++ b/TrafoProbNN.py
@@ -6,7 +6,7 @@ import numpy as np
 import math
 from argparse import ArgumentParser
 from get_any_tree import get_any_tree
-# import progressbar
+#import progressbar
 import os.path
 
 
@@ -21,79 +21,64 @@ def back_transform(var):
     '''
     error_mask = var < -500
 
-    return (-2*error_mask.astype(int)
-            + (~error_mask).astype(int)*(np.exp(var) / (1 + np.exp(var))))
+    return -2*error_mask.astype(int)+(~error_mask).astype(int)*(np.exp(var) / (1 + np.exp(var)))
 
 
+
+#calculate transformation of given variable
 def trafoProbNN(variable_name, event):
-    '''
-    Returns the transformed value of a variable
-
-    Keyword arguments:
-    variable_name -- name of the variable to transform
-    event -- a event in a ttree
-    '''
-    # calculate transformation of given variable
-    # given is a variable name and the event
+    #given is a variable name and the event
     variable = event.__getattr__(variable_name)
 
-    # C heck for problematic ProbNN values
-    if variable <= 0.0 or variable >= 1.0:
-        # -1000 or -2 is the default value when ProbNN could not be read when
-        # creating the tuples
+
+    #Check for problematic ProbNN values
+    if variable <= 0.0 or variable >= 1.0:  #-1000 or -2 is the default value when ProbNN could not be read when creating the tuples
         if variable_name not in problem_branches:
             problem_branches[variable_name] = 1
         else:
             problem_branches[variable_name] += 1
-        return -1000.    # also return -1000
+        return -1000.    #also return -1000
 
     return np.log(variable/(1-variable))
 
 
 def UntrafoProbNN(variable_name, event):
-    # given is a variable name and the event
+    #given is a variable name and the event
     variable = event.__getattr__(variable_name)
 
-    # Check for problematic transformed ProbNN values
+
+    #Check for problematic transformed ProbNN values
     if variable < -500:
         return -2.
     else:
-        return np.exp(variable) / (1 + np.exp(variable))
+        return np.exp(variable)/( 1+np.exp(variable) )
+
+
 
 
 if __name__ == '__main__':
-    # Read options
-    # Create optionparser
-    parser = ArgumentParser(
-        usage=("Tool to transform ProbNN-variables according to"
-               "log(X_ProbNNY/(1-X_ProbNNY))")
-    )
 
-    parser.add_argument("-i", "--input", dest="Input", action="store",
-                        required=True, help="Input ROOT-file")
-    parser.add_argument("-t", "--tree", dest="Tree", action="store",
-                        required=False,
-                        help=("Input TTree (optional if there is only one tree"
-                              " in the input-file)"))
-    parser.add_argument("-o", "--output", dest="Output", action="store",
-                        required=True, help="Output ROOT-file")
-    parser.add_argument("Variables", metavar='V', type=str, nargs='*',
-                        help=("Explicit variable name or variable names to be"
-                              " transformed"))
-    parser.add_argument("-m", "--match", dest="Patterns", action="append",
-                        required=False,
-                        help="Transform all variables matching this pattern")
-    parser.add_argument("-r", "--reverse", dest="Reverse", action="store_true",
-                        help=("Perform inverse transformation"
-                              " exp(X_ProbNNY)/(1+exp(X_ProbNNY))"))
+    #Read options
+    #Create optionparser
+    parser = ArgumentParser(usage="Tool to transform ProbNN-variables according to log(X_ProbNNY/(1-X_ProbNNY))")
 
+    parser.add_argument( "-i", "--input", dest="Input", action="store", required=True, help="Input ROOT-file")
+    parser.add_argument( "-t", "--tree", dest="Tree", action="store", required=False, help="Input TTree (optional if there is only one tree in the input-file)")
+    parser.add_argument( "-o", "--output", dest="Output", action="store", required=True, help="Output ROOT-file")
+    #parser.add_argument( "--progress", dest="progress", action="store_true", default=False, required=False, help="Show detailed progressbar")
+    parser.add_argument( "Variables", metavar='V', type=str, nargs='*', help="Explicit variable name or variable names to be transformed")
+    parser.add_argument( "-m", "--match", dest="Patterns", action="append", required=False,help="Transform all variables matching this pattern" )
+    parser.add_argument( "-r", "--reverse", dest="Reverse", action="store_true", help="Perform inverse transformation exp(X_ProbNNY)/(1+exp(X_ProbNNY))")
+
+    #Parse arguments from command line
     options = parser.parse_args()
 
+    #Open tree and clone it
     inputfile = ROOT.TFile(options.Input, "READ")
     if not inputfile.IsOpen():
         raise SystemExit("Could not open inputfile!")
 
-    if not options.Tree:
+    if options.Tree == None:
         inputtreename = get_any_tree(options.Input)
     else:
         inputtreename = options.Tree
@@ -102,98 +87,97 @@ if __name__ == '__main__':
 
     outputfile = options.Output
 
-    outputfile = ROOT.TFile(options.Output, "RECREATE")
+
+    #Clone tree
+    outputfile =  ROOT.TFile(options.Output,"RECREATE")
     outputtree = inputtree.CloneTree(0)
 
-    # Get explicit variable names
+
+    #Get explicit variable names
     variable_names = options.Variables
 
-    # Create new branches for explicit variable names
+    #Create new branches for explicit variable names
     variable_trafo_branches = []
     for variable_name in variable_names:
-        variable_trafo_branches.append(array.array("d", [0.0]))
+        variable_trafo_branches.append( array.array("d", [0.0]) )
         if options.Reverse:
-            # If var-name has "Trafo" in it, change it to "Untrafo",
-            # otherwise append Untrafo
+            #If var-name has "Trafo" in it, change it to "Untrafo", otherwise append Untrafo
             if "Trafo" in variable_name:
                 outputbranchname = variable_name.replace("Trafo", "Untrafo")
             else:
                 outputbranchname = variable_name + "_Untrafo"
-            outputtree.Branch(outputbranchname, variable_trafo_branches[-1],
-                              outputbranchname+"/D")
+            outputtree.Branch( outputbranchname, variable_trafo_branches[-1], outputbranchname+"/D")
         else:
-            outputtree.Branch(variable_name+"_Trafo",
-                              variable_trafo_branches[-1],
-                              variable_name+"_Trafo/D")
+            outputtree.Branch( variable_name+"_Trafo", variable_trafo_branches[-1], variable_name+"_Trafo/D")
 
-    # Get variable names matching the patterns (if applicable)
+
+    #Get variable names matching the patterns (if applicable)
     if options.Patterns:
         for pattern in options.Patterns:
             for branch in inputtree.GetListOfBranches():
                 if pattern in branch.GetName():
                     variable_name = branch.GetName()
                     variable_names.append(variable_name)
-                    variable_trafo_branches.append(array.array("d", [0.0]))
+                    variable_trafo_branches.append( array.array("d", [0.0]) )
                     if options.Reverse:
-                        # If var-name has "Trafo" in it, change it to
-                        # "Untrafo", otherwise append Untrafo
+                        #If var-name has "Trafo" in it, change it to "Untrafo", otherwise append Untrafo
                         if "Trafo" in variable_name:
-                            outputbranchname = variable_name.replace("Trafo",
-                                                                     "Untrafo")
+                            outputbranchname = variable_name.replace("Trafo", "Untrafo")
                         else:
                             outputbranchname = variable_name + "_Untrafo"
-                        outputtree.Branch(outputbranchname,
-                                          variable_trafo_branches[-1],
-                                          outputbranchname+"/D")
+                        outputtree.Branch( outputbranchname, variable_trafo_branches[-1], outputbranchname+"/D")
                     else:
-                        outputtree.Branch(variable_name+"_Trafo",
-                                          variable_trafo_branches[-1],
-                                          variable_name+"_Trafo/D")
+                        outputtree.Branch( variable_name+"_Trafo", variable_trafo_branches[-1], variable_name+"_Trafo/D")
+
 
     if len(variable_names) is 0:
-        raise SystemExit(
-            ("No variables for transformation given/found "
-             "for {}").format(options.Input))
+        raise SystemExit("No variables for transformation given/found for {}".format(options.Input))
 
-    # Create dictionary that will contain the branch names, where invalid
-    # ProbNN values were encountered (i.e. outside of 0 to 1)
-    # and attached to the branch names the number of events there an error
-    # occured
+
+    #Create dictionary that will contain the branch names, where invalid ProbNN values were encountered (i.e. outside of 0 to 1)
+    #and attached to the branch names the number of events there an error occured
     problem_branches = {}
 
+
+    #Progressbar
     entries = inputtree.GetEntries()
-    print("Processing {0} entries in {2} /{1}".format(entries, inputtreename,
-                                                      options.Input))
+    print("Processing {0} entries in {2} /{1}".format(entries, inputtreename, options.Input))
     print("\nThe following variables will be transformed:")
     print(", ".join(variable_names))
     print("\n")
 
-    for (i, event) in itertools.izip(xrange(entries), inputtree):
+    #widgets = [os.path.basename(options.Output), progressbar.Percentage(), ' ', progressbar.Bar(), ' ', progressbar.ETA()]
+    #pbar = progressbar.ProgressBar(widgets=widgets, maxval=entries).start()
+
+    #pbar.update(0)
+    #Iterate through tree
+    for (i,event) in  itertools.izip(xrange(entries),inputtree):
         inputtree.GetEntry(i)
 
-        # iterate through variables
-        for (variable_name, variable_trafo_branch)\
-                in itertools.izip(variable_names, variable_trafo_branches):
+        #iterate through variables
+        for (variable_name, variable_trafo_branch) in itertools.izip(variable_names, variable_trafo_branches):
             if options.Reverse:
                 variable_trafo_branch[0] = UntrafoProbNN(variable_name, event)
             else:
                 variable_trafo_branch[0] = trafoProbNN(variable_name, event)
 
+        #Fill tree
         outputtree.Fill()
 
-    if problem_branches:
-        print(("\n\nWARNING: There were events with ProbNN-values outside the"
-               " allowed region of [0,1] for {}:").format(options.Input))
-        print("{:<20} {:>15} {:>10}".format(
-            'Branch', 'Probl. Events', 'Percent'))
-        for branch, events in problem_branches.iteritems():
-                print("{:<20} {:>15} {:>10}%".format(
-                    branch, events, float(events)/entries*100.))
-        print(("\t=> Setting these to -1000 (Default value for"
-               "ProbNN-variables if none was found when creating the ntuple)"))
+        #Progressbar
+    #    if options.progress:    #detailed progress
+    #        pbar.update(i+1)
+    #    else:
+    #        if (i+1) % (entries/10) == 0:
+    #            pbar.update(i+1)
 
-    print(("\nFinished processing {0} entries in {2} /{1}\n\t=> Writing to"
-           " {3}").format(entries, inputtreename,
-                          options.Input, options.Output))
+    if problem_branches:
+        print("\n\nWARNING: There were events with ProbNN-values outside the allowed region of [0,1] for {}:".format(options.Input))
+        print("{:<20} {:>15} {:>10}".format('Branch','Probl. Events', 'Percent'))
+        for branch, events in problem_branches.iteritems():
+                print("{:<20} {:>15} {:>10}%".format(branch, events, float(events)/entries*100.))
+        print("\t=> Setting these to -1000 (Default value for ProbNN-variables if none was found when creating the ntuple)")
+
+    print("\nFinished processing {0} entries in {2} /{1}\n\t=> Writing to {3}".format(entries, inputtreename, options.Input, options.Output))
     outputtree.Write()
     outputfile.Close()

--- a/pidtool.py
+++ b/pidtool.py
@@ -366,8 +366,8 @@ def resample_branch(options):
         t_path = options.tree.split('/')[:-1]
         t_dir = f.Get("/".join(t_path))
         t_dir.cd()
-    print(resampled_data[pid_names].tail())
-    array2tree(resampled_data[pid_names].to_records(index=False),
+    print(resampled_data.tail())
+    array2tree(resampled_data.to_records(index=False),
                tree=t, name=options.tree)
     t.Write()
     f.Close()

--- a/pidtool.py
+++ b/pidtool.py
@@ -6,54 +6,81 @@ from numpy.random import choice
 import logging
 import json
 import os
+from TrafoProbNN import back_transform
+import ROOT as R
+import multiprocessing as mp
+
 
 logging.basicConfig(level=logging.INFO)
 
-class Resampler(object):
+
+class Resampler:
 
     def __init__(self, *args):
         # Choose histogram size according to bin edges
         # Take under/overflow into account for dependent variables only
         edges = []
-        for arg in args[:-1]:
-            edges.append(np.append(np.append([-np.inf], arg), [np.inf]))
-        edges.append(args[-1])
-        self.edges = edges
+        self.histogram = None
+        if args:
+            print('Creating resampler with args')
+            for arg in args[:-1]:
+                edges.append(np.append(np.append([-np.inf], arg), [np.inf]))
+            edges.append(args[-1])
+            self.edges = edges
 
-        self.histogram = np.zeros(map(lambda x: len(x) - 1, self.edges))
+            self.histogram = np.zeros(map(lambda x: len(x) - 1, self.edges))
+
+    def copy(self):
+        '''
+        Creats a copy of the resampler
+        '''
+        rv = Resampler()
+        rv.edges = list(self.edges)
+        rv.histogram = self.histogram.copy()
+        return rv
 
     def learn(self, features, weights=None):
         assert(len(features) == len(self.edges))
 
         features = np.array(features)
 
-        h , _ = np.histogramdd(features.T, bins=self.edges, weights=weights)
+        h, _ = np.histogramdd(features.T, bins=self.edges, weights=weights)
         self.histogram += h
 
     def sample(self, features):
 
         assert(len(features) == len(self.edges) - 1)
         args = np.array(features)
-        idx = [np.searchsorted(edges, vals) - 1 for edges, vals in zip(self.edges, args)]
+        idx = [np.searchsorted(edges, vals) - 1
+               for edges, vals in zip(self.edges, args)]
         tmp = self.histogram[idx]
         # Fix negative bins (resulting from possible negative weights) to zero
         tmp[tmp < 0] = 0
         norm = np.sum(tmp, axis=1)
-        probs = tmp / norm[:,np.newaxis]
+        probs = tmp / norm[:, np.newaxis]
         sampled_bin = []
         for i in range(tmp.shape[0]):
-            sampled_bin.append(choice(tmp.shape[1], p=probs[i,:]))
+            sampled_bin.append(choice(tmp.shape[1], p=probs[i, :]))
         sampled_bin = np.array(sampled_bin)
         sampled_val = np.random.uniform(self.edges[-1][sampled_bin],
                                         self.edges[-1][sampled_bin + 1],
                                         size=len(sampled_bin))
         # If the histogram is empty, we can't sample
-        sampled_val[norm == 0] = np.nan
+        sampled_val[norm == 0] = -1000
 
+        assert(len(features[0]) == len(sampled_val)), \
+            ('Resampled values are too few.\n'
+             'Features length: {}\nresampled length:{}'.format(
+                len(features[0]), len(sampled_val)))
         return sampled_val
 
+
 def rooBinning_to_list(rooBinning):
-    return [rooBinning.binLow(i) for i in range(rooBinning.numBins())]+[rooBinning.binHigh(rooBinning.numBins()-1)]
+    return [
+        rooBinning.binLow(i)
+        for i in range(rooBinning.numBins())
+        ] + [rooBinning.binHigh(rooBinning.numBins() - 1)]
+
 
 def grab_data(options):
     from root_pandas import read_root
@@ -71,24 +98,33 @@ def grab_data(options):
 
     logging.info("Saving nTuples to " + options.output)
 
-    with open('raw_data.json') as f:
+    with open(options.config) as f:
         locations = json.load(f)
     if options.particles is not None:
-        locations =  [sample for sample in locations if sample["particle"] in options.particles]
+        locations = [
+            sample
+            for sample in locations if sample["particle"] in options.particles
+        ]
 
     for sample in locations:
-        output = options.output +'/{particle}_Stripping{stripping}_Magnet{magnet}.root'.format(**sample)
+        output = options.output + \
+            '/{particle}_Stripping{stripping}_Magnet{magnet}.root'.format(
+                **sample
+            )
         ff = TFile(output, 'recreate')
         ff.Close()
         for input in sample['paths']:
             logging.info('Opening file {}'.format(input))
             f = TFile.Open(input)
+            print(input)
             ws = f.Get(f.GetListOfKeys().First().GetName())
             ROOT.SetOwnership(ws, False)
             data = ws.allData().front()
             ROOT.RooAbsData.setDefaultStorageType(ROOT.RooAbsData.Tree)
             ff = TFile(output, 'update')
-            dset = ROOT.RooDataSet('tree', 'tree', data.get(), ROOT.RooFit.Import(data))
+            dset = ROOT.RooDataSet(
+                'tree', 'tree', data.get(), ROOT.RooFit.Import(data)
+            )
             logging.info('Saving data to {}'.format(output))
             dset.tree().Write('tree')
             ff.Close()
@@ -99,58 +135,134 @@ def grab_data(options):
                 from IPython import embed
                 embed()
 
+
 def create_resamplers(options):
     import os.path
     import pickle
     from root_pandas import read_root
     from PIDPerfScripts.Binning import GetBinScheme
 
-    if options.binning_file:
-        import imp
-        try:
-            imp.load_source('userbinning', options.binning_file)
-        except IOError:
-            raise IOError("Failed to load binning scheme file '{scheme_file}'".format(scheme_file=options.binning_file))
+    # TupleToolANNPID stores all available tunes whereas TupleToolPid stores
+    # only the default tune as {}_ProbNNX
+    # Information on the default tunes can be found here:
+    # https://gitlab.cern.ch/lhcb/Rec/blob/master/Rec/ChargedProtoANNPID/python/ChargedProtoANNPID/Configuration.py
+    pid_variables = [
+        '{}_CombDLLK', '{}_CombDLLmu', '{}_CombDLLp', '{}_CombDLLe',
+        # ProbNN
+        '{}_V3ProbNNK', '{}_V3ProbNNpi', '{}_V3ProbNNmu', '{}_V3ProbNNp',
+        '{}_V3ProbNNe', '{}_V3ProbNNghost',
+        # transformed ProbNN with log( var/(1-var) )
+        '{}_V3ProbNNK_Trafo', '{}_V3ProbNNpi_Trafo', '{}_V3ProbNNmu_Trafo',
+        '{}_V3ProbNNp_Trafo', '{}_V3ProbNNe_Trafo', '{}_V3ProbNNghost_Trafo',
+        # Same for V2
+        '{}_V2ProbNNK', '{}_V2ProbNNpi', '{}_V2ProbNNmu', '{}_V2ProbNNp',
+        '{}_V2ProbNNe', '{}_V2ProbNNghost', '{}_V2ProbNNK_Trafo',
+        '{}_V2ProbNNpi_Trafo', '{}_V2ProbNNmu_Trafo', '{}_V2ProbNNp_Trafo',
+        '{}_V2ProbNNe_Trafo', '{}_V2ProbNNghost_Trafo'
+    ]
+    # # Same for V1
+    # '{}_V1ProbNNK', '{}_V1ProbNNpi', '{}_V1ProbNNmu', '{}_V1ProbNNp',
+    # '{}_V1ProbNNe', '{}_V1ProbNNghost', '{}_V1ProbNNK_Trafo',
+    # '{}_V1ProbNNpi_Trafo', '{}_V1ProbNNmu_Trafo', '{}_V1ProbNNp_Trafo',
+    # '{}_V1ProbNNe_Trafo', '{}_V1ProbNNghost_Trafo',
+    # #Same for V4
+    # '{}_V4ProbNNK', '{}_V4ProbNNpi', '{}_V4ProbNNmu', '{}_V4ProbNNp',
+    # '{}_V4ProbNNe', '{}_V4ProbNNghost', '{}_V4ProbNNK_Trafo',
+    # '{}_V4ProbNNpi_Trafo', '{}_V4ProbNNmu_Trafo', '{}_V4ProbNNp_Trafo',
+    # '{}_V4ProbNNe_Trafo', '{}_V4ProbNNghost_Trafo']
 
-    pid_variables = ['{}_CombDLLK', '{}_CombDLLmu', '{}_CombDLLp', '{}_CombDLLe', '{}_V3ProbNNK', '{}_V3ProbNNpi', '{}_V3ProbNNmu', '{}_V3ProbNNp']
-    kin_variables = ['{}_P', '{}_Eta','nTracks']
+    kin_variables = ['{}_P', '{}_Eta', 'nTracks']
 
-
-    with open('raw_data.json') as f:
+    with open(options.config) as f:
         locations = json.load(f)
     if options.particles:
-        locations = [sample for sample in locations if sample["particle"] in options.particles]
+        locations = [
+            sample
+            for sample in locations if sample["particle"] in options.particles
+        ]
     if options.both_magnet_orientations:
-        locations = [sample for sample in locations if sample["magnet"]=="Up"] # we use both maagnet orientations on the first run
+        # we use both maagnet orientations on the first run
+        locations = [
+            sample for sample in locations if sample["magnet"] == "Up"
+        ]
     for sample in locations:
-        binning_P = rooBinning_to_list(GetBinScheme(sample['branch_particle'], "P", options.binning_name)) #last argument takes name of user-defined binning
-        binning_ETA = rooBinning_to_list(GetBinScheme(sample['branch_particle'], "ETA", options.binning_name)) #last argument takes name of user-defined binning
-        binning_nTracks = rooBinning_to_list(GetBinScheme(sample['branch_particle'], "nTracks", options.binning_name)) #last argument takes name of user-defined binning
+        # last argument takes name of user-defined binning
+        binning_P = rooBinning_to_list(
+            GetBinScheme(sample['branch_particle'], "P", None)
+        )
+        # last argument takes name of user-defined binning
+        # TODO: let user pass this argument
+        binning_ETA = rooBinning_to_list(
+            GetBinScheme(sample['branch_particle'], "ETA", None)
+        )
+        # last argument takes name of user-defined binning
+        # TODO: let user pass this argument
+        binning_nTracks = rooBinning_to_list(GetBinScheme(
+            sample['branch_particle'], "nTracks", None))
         if options.both_magnet_orientations:
-            if sample["magnet"]=="Up":  
-                data =  [options.location + '/{particle}_Stripping{stripping}_MagnetUp.root'  .format(**sample)]
-                data += [options.location + '/{particle}_Stripping{stripping}_MagnetDown.root'.format(**sample)]
-                resampler_location = '{particle}_Stripping{stripping}_MagnetAny.pkl'.format(**sample)
+            if sample["magnet"] == "Up":
+                data = [
+                    options.location +
+                    '/{particle}_Stripping{stripping}_MagnetUp.root'.format(
+                        **sample
+                    )
+                ]
+                data += [
+                    options.location +
+                    '/{particle}_Stripping{stripping}_MagnetDown.root'.format(
+                        **sample
+                    )
+                ]
+                resampler_location = options.saveto + \
+                    '/{particle}_Stripping{stripping}_MagnetAny.pkl'.format(
+                        **sample
+                    )
         else:
-            data = [options.location + '/{particle}_Stripping{stripping}_Magnet{magnet}.root'.format(**sample)]
-            resampler_location = '{particle}_Stripping{stripping}_Magnet{magnet}.pkl'.format(**sample)
+            data = [
+                options.location +
+                '/{particle}_Stripping{stripping}_Magnet{magnet}.root'.format(
+                    **sample
+                )
+            ]
+            resampler_location = options.saveto + \
+                '/{particle}_Stripping{stripping}_Magnet{magnet}.pkl'.format(
+                    **sample
+                )
         if os.path.exists(resampler_location):
             os.remove(resampler_location)
         resamplers = dict()
-        deps = map(lambda x: x.format(sample['branch_particle']), kin_variables)
-        pids = map(lambda x: x.format(sample['branch_particle']), pid_variables)
+        deps = map(
+            lambda x: x.format(sample['branch_particle']), kin_variables
+        )
+        pids = map(
+            lambda x: x.format(sample['branch_particle']), pid_variables
+        )
         for pid in pids:
             if "DLL" in pid:
-                target_binning = np.linspace(-150, 150, 300) # binning for DLL
+                # binning for DLL
+                target_binning = np.linspace(-150, 150, 300)
+            elif "ProbNN" in pid and "Trafo" in pid:
+                # binning for transformed ProbNN
+                target_binning = np.linspace(-30, 30, 300)
             elif "ProbNN" in pid:
-                target_binning = np.linspace(0, 1, 100) # binning for ProbNN
+                # binning for (raw) ProbNN
+                target_binning = np.linspace(0, 1, 100)
             else:
                 raise Exception
-            resamplers[pid] = Resampler(binning_P, binning_ETA, binning_nTracks, target_binning)
+            resamplers[pid] = Resampler(
+                binning_P, binning_ETA, binning_nTracks, target_binning
+            )
+
         for dataSet in data:
-            for i, chunk in enumerate(read_root(dataSet, columns=deps + pids + ['nsig_sw'], chunksize=100000, where=options.cutstring)): # where is None if option is not set
+            # where is None if option is not set
+            for i, chunk in enumerate(read_root(
+                dataSet, options.tree, columns=deps + pids + ['nsig_sw'],
+                    chunksize=100000, where=options.cutstring)):
                 for pid in pids:
-                    resamplers[pid].learn(chunk[deps + [pid]].values.T, weights=chunk['nsig_sw'])
+                    resamplers[pid].learn(
+                        chunk[deps + [pid]].values.T,
+                        weights=chunk['nsig_sw']
+                    )
                 logging.info('Finished chunk {}'.format(i))
         with open(resampler_location, 'wb') as f:
             pickle.dump(resamplers, f)
@@ -158,19 +270,14 @@ def create_resamplers(options):
 
 def resample_branch(options):
     import pickle
+    from root_numpy import tree2array, array2tree, list_branches
     from root_pandas import read_root
-    try:
-        os.remove(options.output_file)
-    except OSError:
-        pass
-
-    if options.seed:
-        np.random.seed(options.seed)
 
     with open(options.configfile) as f:
         config = json.load(f)
 
-    #load resamplers into config dictionary
+    logging.info('Loading resamplers...')
+    # load resamplers into config dictionary
     for task in config["tasks"]:
         with open(task["resampler_path"], 'rb') as f:
             resamplers = pickle.load(f)
@@ -178,51 +285,194 @@ def resample_branch(options):
                 try:
                     pid["resampler"] = resamplers[pid["kind"]]
                 except KeyError:
-                    print (resamplers)
-                    logging.error("No resampler found for {kind} in {picklefile}.".format(kind=pid["kind"], picklefile=task["resampler_path"]))
+                    print(resamplers)
+                    logging.error(
+                        "No resampler found for {kind} in {picklefile}".format(
+                            kind=pid["kind"], picklefile=task["resampler_path"]
+                        )
+                    )
                     raise
 
-    chunksize = 100000
-    for i, chunk in enumerate(read_root(options.source_file, key=options.input_tree, ignore=["evname","year","*_COV_"], chunksize=chunksize)):
-        for task in config["tasks"]:
-            deps = chunk[task["features"]]
-            for pid in task["pids"]:
-                chunk[pid["name"]] = pid["resampler"].sample(deps.values.T)
-        chunk.to_root(options.output_file, key=options.output_tree, mode="a")
-        logging.info('Processed {} entries'.format((i+1) * chunksize))
+    needed_branches = [f for task in config["tasks"] for f in task['features']]
+
+    logging.info('Loading data...')
+    data = read_root(
+        options.source_file, options.tree, columns=needed_branches
+    )
+    pid_names = []
+
+    for task in config["tasks"]:
+        for pid in task["pids"]:
+            pid_names.append(pid["name"])
+            if options.transform and 'Trafo' in pid["name"]:
+                pid_names.append(pid["name"].replace("Trafo", "Untrafo"))
+    if any([pid_name in list_branches(options.source_file, treename=options.tree) for pid_name in pid_names]):
+        raise Exception('Branches exist - resampling seems already to be done.')
+
+    logging.info('Resampling {} events...'.format(len(data)))
+
+    p = mp.Pool(processes=options.num_cpu)
+    var_name = []
+    args = []
+
+    for task in config["tasks"]:
+        deps = data[task["features"]]
+        for pid in task["pids"]:
+            var_name.append(pid['name'])
+            args.append((pid["resampler"], deps.values.T))
+            # if options.num_cpu == 1:
+            #     data[pid["name"]] = pid["resampler"].sample(deps.values.T)
+            # else:
+            #     resample_parallel(data, pid["name"], deps, options.num_cpu, pid["resampler"])
+
+    resampled = p.map_async(resample_thread, args).get()
+
+    for idx, var in enumerate(var_name):
+        data[var] = resampled[idx]
+        if 'Trafo' in pid["name"] and options.transform:
+            logging.info('Back trafo for {}'.format(var))
+            data[var.replace("Trafo", "Untrafo")] = back_transform(resampled[idx])
+
+    # if options.transform:
+    #     logging.info('Back transfroming ProbNNs...')
+    #     for task in config["tasks"]:
+    #         for pid in task["pids"]:
+    #             if 'Trafo' in pid["name"]:
+    #                 data[pid["name"].replace("Trafo", "Untrafo")] = back_transform(data[pid["name"]])
+
+    logging.info('Writing output...')
+    f = R.TFile(options.source_file, 'UPDATE')
+    t = f.Get(options.tree)
+    print(data[pid_names].tail())
+    array2tree(data[pid_names].to_records(index=False), tree=t, name=options.tree)
+    t.Write()
+    f.Close()
 
 
-with open('raw_data.json') as configfile:
-    locations = json.load(configfile)
-particle_set = set([sample["particle"] for sample in locations])
+def resample_thread(res_deps):
+    return res_deps[0].sample(res_deps[1])
+
+
+def resample_parallel(data, name, deps, num_cpu, res):
+    # from threading import Thread
+    start = 0
+
+    q = mp.Queue()
+
+    threads = []
+    arrays = []
+    for i in range(num_cpu):
+        if i == num_cpu - 1:
+            stop = len(data)
+        else:
+            stop = start + int(len(data) / num_cpu)
+        ar = np.array([0]*(stop-start))
+        logging.info('Starting thread for events {s} to {e}'.format(s=start, e=stop))
+        t = mp.Process(target=resample_thread, args=(deps, start, stop, res.copy(), ar, ))
+        t.start()
+        threads.append(t)
+        arrays.append(ar)
+
+        start += int(len(data) / num_cpu)
+
+    for t in threads:
+        t.join()
+
+    resampled = np.concatenate(arrays)
+
+    assert len(resampled) == len(data), \
+        "Mismatch in length of resampled branch and data"
+
+    data[name] = resampled
+
 
 parser = argparse.ArgumentParser()
 subparsers = parser.add_subparsers()
 
-grab = subparsers.add_parser('grab_data', help='Downloads PID calib data from EOS and saves it as NTuples')
+grab = subparsers.add_parser(
+    'grab_data',
+    help='Downloads PID calib data from EOS and saves it as NTuples'
+)
 grab.set_defaults(func=grab_data)
-grab.add_argument('output', help="Directory where grabbed data is being stored.")
-grab.add_argument('--particles', nargs='*', help="Optional subset of particles for which calibration data will be downloaded. Choose from "+", ".join(particle_set))
+grab.add_argument('-c', '--config', default="raw_data.json",
+                  help="Config-file with raw_data in it."
+                  " Default: raw_data.json")
+grab.add_argument(
+    'output',
+    help="Directory where grabbed data is being stored."
+)
+grab.add_argument(
+    '--particles', nargs='*',
+    help="Optional subset of particles for which calibration data will be "
+    "downloaded."
+)
 
-create = subparsers.add_parser('create_resamplers', help='Generates resampling histograms from NTuples')
+
+create = subparsers.add_parser(
+    'create_resamplers', help='Generates resampling histograms from NTuples'
+)
 create.set_defaults(func=create_resamplers)
-create.add_argument("location", help="Directory where grab_data downloaded the .root - files.")
-create.add_argument('--particles', nargs='*', help="Optional subset of particles for which resamplers will be created. Choose from "+", ".join(particle_set))
-create.add_argument('--cutstring', help="Optional cutstring. For example you can cut on the runNumber.")
-create.add_argument("--merge-magnet-orientations", dest='both_magnet_orientations', action='store_true', default=False, help='Create a resampler that combines the raw data for magup and mag down.')
-create.add_argument("--binning_name", type=str, default=None, help="Parameter to specify a non-default binning.")
-create.add_argument("--binning_file", type=str, default=None, help="File containing a user-defined binning. The name of the user-defined binning must be passed via the --binning_name parameter.")
+create.add_argument("location", help="Directory where input files are stored.")
+create.add_argument(
+    "saveto",
+    help="Directory where to save the resamplers as .pkl - files."
+)
+create.add_argument(
+    '--particles', nargs='*',
+    help="Optional subset of particles for which resamplers will be created."
+)
+create.add_argument(
+    '--cutstring',
+    help="Optional cutstring. For example you can cut on the runNumber."
+)
+create.add_argument(
+    "--merge-magnet-orientations", dest='both_magnet_orientations',
+    action='store_true', default=False,
+    help='Create a resampler that combines the raw data for magup and magdown.'
+)
+create.add_argument(
+    '-c', '--config', default="raw_data.json",
+    help="Config-file with raw_data in it. Default: raw_data.json"
+)
+create.add_argument(
+    '--tree',
+    help="Optional tree name to use. Has to be used if you have multiple trees"
+    " in file or have several subsets of the same tree."
+)
 
-resample = subparsers.add_parser('resample_branch', help='Uses histograms to add resampled PID branches to a dataset')
+
+resample = subparsers.add_parser(
+    'resample_branch',
+    help='Uses histograms to add resampled PID branches to a dataset'
+)
 resample.set_defaults(func=resample_branch)
 resample.add_argument("configfile")
 resample.add_argument("source_file")
-resample.add_argument("output_file")
-resample.add_argument('--input_tree', help="Path to tree in input file. Should be used if input file has nested structure or contains multiple trees.")
-resample.add_argument('--output_tree', help="Name of tree in output file. Sub-folders are not supported.")
-resample.add_argument('--seed', default=None, type=int, help="Sets a seed for the random number generator to make the resampling reproducible.")
+# resample.add_argument("output_file")
+resample.add_argument(
+    "--num_cpu",
+    "-n",
+    help="Number of cpus used for resampling",
+    default=1,
+    type=int
+)
+resample.add_argument(
+    '--tree', help="Optional tree name to use. Should be used if you have "
+    "multiple trees in file."
+)
+resample.add_argument(
+    '--outputtree',
+    help="Optional tree name to use. Should be used if you have multiple trees"
+    " in file or if you have a slash in your tree name."
+)
+resample.add_argument(
+    '--transform', action='store_true',
+    help='Perform in place back transformation for ProbNN variables'
+)
 
 if __name__ == '__main__':
+#    import multiprocessing as mp
+#    mp.set_start_method('spawn')
+
     options = parser.parse_args()
     options.func(options)
-

--- a/pidtool.py
+++ b/pidtool.py
@@ -344,7 +344,7 @@ def resample_branch(options):
 
         for idx, var in enumerate(var_name):
             resampled_data_chunk[var] = resampled[idx]
-            if 'Trafo' in pid["name"] and options.transform:
+            if 'Trafo' in var and options.transform:
                 logging.info('Back trafo for {}'.format(var))
                 resampled_data_chunk[var.replace("Trafo", "Untrafo")] = \
                     back_transform(resampled[idx])

--- a/pidtool.py
+++ b/pidtool.py
@@ -340,9 +340,15 @@ def resample_branch(options):
     #             if 'Trafo' in pid["name"]:
     #                 data[pid["name"].replace("Trafo", "Untrafo")] = back_transform(data[pid["name"]])
 
+    # t_name = options.tree.split('/')[-1]
+
     logging.info('Writing output...')
     f = R.TFile(options.source_file, 'UPDATE')
     t = f.Get(options.tree)
+    if '/' in options.tree:
+        t_path = options.tree.split('/')[:-1]
+        t_dir = f.Get("/".join(t_path))
+        t_dir.cd()
     print(data[pid_names].tail())
     array2tree(data[pid_names].to_records(index=False), tree=t, name=options.tree)
     t.Write()


### PR DESCRIPTION
major changes are:
* parallelisation during resampling
   * each variable, that is to be resampled, can be processed in an individual proccess
   * More processes than variables that are resampled do not make sense, but are not harmful
   * Added comandline argument `--num_cpu` with default set to 1
* Resampled variables are added to the root file in place (no copy is created, so keep a backup yourself)
   * huge advantage in terms of speed up and disk space
   * Removed command line argument `output_file` because it is now the same as the `source_file`
   * Closes #16 
* Transformation and back-transformation implemented for ProbNN variables