### PR TITLE
adds that mis-id background resamplers can be used

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,18 +1,26 @@
 {
     "tasks": [
         {
-            "resampler_path" : "/fhgfs/groups/e5/lhcb/analysis/Common/PIDCalib/Kaon_Stripping20_MagnetUp.pkl",
+            "resampler_path" : "Kaon_Stripping20_MagnetUp.pkl",
             "features" : ["Kplus_P", "Kplus_LOKI_ETA", "nTracks"],
             "trueid": [321, -321],
             "trueid_branch": "Kplus_TRUEID",
             "pids" : [{"kind" : "K_CombDLLK", "name" : "Kplus_PIDK_corrected"}]
         },
         {
-            "resampler_path" : "/fhgfs/groups/e5/lhcb/analysis/Common/PIDCalib/Kaon_Stripping20_MagnetUp.pkl",
+            "resampler_path" : "Kaon_Stripping20_MagnetUp.pkl",
             "features" : ["Kminus_P", "Kminus_LOKI_ETA", "nTracks"],
             "trueid": [321, -321],
             "trueid_branch": "Kminus_TRUEID",
             "pids" : [{"kind" : "K_CombDLLK", "name" : "Kminus_PIDK_corrected"}]
         }
-        ]
+    ],
+    "backgrounds": [
+          {
+              "resampler_path" : "P_Stripping20_MagnetDown.pkl",
+              "trueid": [2212, -2212],
+              "pids" : [
+              "pids" : [{"kind" : "P_CombDLLK"}]
+          }
+    ]
 }

--- a/pidtool.py
+++ b/pidtool.py
@@ -317,7 +317,7 @@ def _resample_branch(options):
             logging.error('Specify true ids on all tasks or on no task.')
             exit()
 
-    for task in config['tasks']:
+    for task in config['tasks'] + config.get('backgrounds', []):
         if 'trueid_branch' in task:
             trueid_branches.append(task['trueid_branch'])
         with open(task['resampler_path'], 'rb') as f:


### PR DESCRIPTION
Previously it was not possible to configure resamplers for particles that are not tracks in the sample, e.g. you could not resample protons that are reconstructed as kaon candidates if you had no proton tracks reconstructed.